### PR TITLE
remove async from framer

### DIFF
--- a/givenergy_modbus/client/client.py
+++ b/givenergy_modbus/client/client.py
@@ -118,7 +118,7 @@ class Client:
         while hasattr(self, 'reader') and self.reader and not self.reader.at_eof():
             frame = await self.reader.read(300)
             # await self.debug_frames['all'].put(frame)
-            async for message in self.framer.decode(frame):
+            for message in self.framer.decode(frame):
                 _logger.debug(f'Processing {message}')
                 if isinstance(message, ExceptionBase):
                     _logger.warning(f'Expected response never arrived but resulted in exception: {message}')

--- a/givenergy_modbus/framer.py
+++ b/givenergy_modbus/framer.py
@@ -1,7 +1,7 @@
 import logging
 from abc import ABC
 from collections.abc import AsyncIterator
-from typing import Callable, Optional, Type, Union
+from typing import Callable, Optional, Type, Union, Iterator
 
 from givenergy_modbus.exceptions import ExceptionBase, InvalidFrame, InvalidPduState
 from givenergy_modbus.pdu import BasePDU, ClientIncomingMessage, ServerIncomingMessage
@@ -79,7 +79,7 @@ class Framer(ABC):
     _buffer: bytes = b''
     pdu_class: 'Type[BasePDU]'
 
-    async def decode(self, data: bytes) -> AsyncIterator[Union[BasePDU, ExceptionBase]]:
+    def decode(self, data: bytes) -> Iterator[Union[BasePDU, ExceptionBase]]:
         """Receive incoming network data and attempt to decode frames into messages.
 
         This method receives raw bytes as passed from the underlying transport and appends it onto an internal


### PR DESCRIPTION
There doesn't seem any good reason for the framer to be async. It just takes a byte array, and carves it into individual messages. It doesn't do any i/o and it simply returns the messages, without itself doing anything with them.

Having it asynchronous precludes using it in any synchronous tools (which are much easier to debug with). But making it synchronous does not preclude using it in an async context.