### PR TITLE
complete migration of commands to be a class

### DIFF
--- a/givenergy_modbus/client/client.py
+++ b/givenergy_modbus/client/client.py
@@ -5,7 +5,6 @@ import socket
 from asyncio import Future, Queue, StreamReader, StreamWriter, Task
 from typing import Callable, Dict, List, Optional, Sequence, Tuple
 
-from . import commands
 from ..exceptions import (
     CommunicationError,
     ExceptionBase,
@@ -130,15 +129,14 @@ class Client:
 
         return self.plant
 
-    # For now, client.commands just returns a reference to
-    # the commands module. Later, it will return an instance
-    # of some class which has access to the plant, since
-    # commands will need to validated against the particular
-    # model of device the client is attached to.
     @property
     def commands(self):
         """Access to the library of commands."""
-        return commands
+
+        # defer import until here to avoid circularity
+        from .commands import Commands
+
+        return Commands(self)
 
     async def watch_plant(
         self,

--- a/givenergy_modbus/client/commands.py
+++ b/givenergy_modbus/client/commands.py
@@ -12,6 +12,7 @@ from datetime import datetime
 from typing import Optional
 from typing_extensions import deprecated  # type: ignore[attr-defined]
 
+from .client import Client
 from ..model import TimeSlot
 from ..model.inverter import (
     Inverter,
@@ -61,299 +62,285 @@ class RegisterMap:
     BATTERY_PAUSE_MODE = 318
 
 
-# Helper to look up an inverter holding register by name
-# and prepare a write request. Value range checking gets
-# done automatically.
-def write_named_register(name: str, value: int) -> TransparentRequest:
-    """Prepare a request to write to a register."""
-    idx = Inverter.lookup_writable_register(name, value)
-    return WriteHoldingRegisterRequest(idx, value)
+class Commands:
+    """High-level methods for interacting with a remote system."""
 
+    def __init__(self, client: Client):
+        self.client = client
 
-def refresh_plant_data(
-    complete: bool, number_batteries: int = 1, max_batteries: int = 5
-) -> list[TransparentRequest]:
-    """Refresh plant data."""
-    requests: list[TransparentRequest] = [
-        ReadInputRegistersRequest(
-            base_register=0, register_count=60, slave_address=0x32
-        ),
-        ReadInputRegistersRequest(
-            base_register=180, register_count=60, slave_address=0x32
-        ),
-    ]
-    if complete:
-        requests.append(
-            ReadHoldingRegistersRequest(
+    # Helper to look up an inverter holding register by name
+    # and prepare a write request. Value range checking gets
+    # done automatically.
+    def write_named_register(self, name: str, value: int) -> TransparentRequest:
+        """Prepare a request to write to a register."""
+        idx = Inverter.lookup_writable_register(name, value)
+        return WriteHoldingRegisterRequest(idx, value)
+
+    def refresh_plant_data(
+        self, complete: bool, number_batteries: int = 1, max_batteries: int = 5
+    ) -> list[TransparentRequest]:
+        """Refresh plant data."""
+        requests: list[TransparentRequest] = [
+            ReadInputRegistersRequest(
                 base_register=0, register_count=60, slave_address=0x32
-            )
-        )
-        requests.append(
-            ReadHoldingRegistersRequest(
-                base_register=60, register_count=60, slave_address=0x32
-            )
-        )
-        requests.append(
-            ReadHoldingRegistersRequest(
-                base_register=120, register_count=60, slave_address=0x32
-            )
-        )
-        requests.append(
+            ),
             ReadInputRegistersRequest(
-                base_register=120, register_count=60, slave_address=0x32
-            )
-        )
-        number_batteries = max_batteries
-    for i in range(number_batteries):
-        requests.append(
-            ReadInputRegistersRequest(
-                base_register=60, register_count=60, slave_address=0x32 + i
-            )
-        )
-    return requests
-
-
-def disable_charge_target() -> list[TransparentRequest]:
-    """Removes SOC limit and target 100% charging."""
-    return [
-        WriteHoldingRegisterRequest(RegisterMap.ENABLE_CHARGE_TARGET, False),
-        WriteHoldingRegisterRequest(RegisterMap.CHARGE_TARGET_SOC, 100),
-    ]
-
-
-def set_charge_target(target_soc: int) -> list[TransparentRequest]:
-    """Sets inverter to stop charging when SOC reaches the desired level. Also referred to as "winter mode"."""
-    if not 4 <= target_soc <= 100:
-        raise ValueError(f"Charge Target SOC ({target_soc}) must be in [4-100]%")
-    ret = set_enable_charge(True)
-    if target_soc == 100:
-        ret.extend(disable_charge_target())
-    else:
-        ret.append(WriteHoldingRegisterRequest(RegisterMap.ENABLE_CHARGE_TARGET, True))
-        ret.append(
-            WriteHoldingRegisterRequest(RegisterMap.CHARGE_TARGET_SOC, target_soc)
-        )
-    return ret
-
-
-def set_enable_charge(enabled: bool) -> list[TransparentRequest]:
-    """Enable the battery to charge, depending on the mode and slots set."""
-    return [WriteHoldingRegisterRequest(RegisterMap.ENABLE_CHARGE, enabled)]
-
-
-def set_enable_discharge(enabled: bool) -> list[TransparentRequest]:
-    """Enable the battery to discharge, depending on the mode and slots set."""
-    return [WriteHoldingRegisterRequest(RegisterMap.ENABLE_DISCHARGE, enabled)]
-
-
-def set_inverter_reboot() -> list[TransparentRequest]:
-    """Restart the inverter."""
-    return [WriteHoldingRegisterRequest(RegisterMap.REBOOT, 100)]
-
-
-def set_calibrate_battery_soc() -> list[TransparentRequest]:
-    """Set the inverter to recalibrate the battery state of charge estimation."""
-    return [WriteHoldingRegisterRequest(RegisterMap.SOC_FORCE_ADJUST, 1)]
-
-
-@deprecated("use set_enable_charge(True) instead")
-def enable_charge() -> list[TransparentRequest]:
-    """Enable the battery to charge, depending on the mode and slots set."""
-    return set_enable_charge(True)
-
-
-@deprecated("use set_enable_charge(False) instead")
-def disable_charge() -> list[TransparentRequest]:
-    """Prevent the battery from charging at all."""
-    return set_enable_charge(False)
-
-
-@deprecated("use set_enable_discharge(True) instead")
-def enable_discharge() -> list[TransparentRequest]:
-    """Enable the battery to discharge, depending on the mode and slots set."""
-    return set_enable_discharge(True)
-
-
-@deprecated("use set_enable_discharge(False) instead")
-def disable_discharge() -> list[TransparentRequest]:
-    """Prevent the battery from discharging at all."""
-    return set_enable_discharge(False)
-
-
-def set_discharge_mode_max_power() -> list[TransparentRequest]:
-    """Set the battery discharge mode to maximum power, exporting to the grid if it exceeds load demand."""
-    return [WriteHoldingRegisterRequest(RegisterMap.BATTERY_POWER_MODE, 0)]
-
-
-def set_discharge_mode_to_match_demand() -> list[TransparentRequest]:
-    """Set the battery discharge mode to match demand, avoiding exporting power to the grid."""
-    return [WriteHoldingRegisterRequest(RegisterMap.BATTERY_POWER_MODE, 1)]
-
-
-@deprecated("Use set_battery_soc_reserve(val) instead")
-def set_shallow_charge(val: int) -> list[TransparentRequest]:
-    """Set the minimum level of charge to maintain."""
-    return set_battery_soc_reserve(val)
-
-
-def set_battery_soc_reserve(val: int) -> list[TransparentRequest]:
-    """Set the minimum level of charge to maintain."""
-    # TODO what are valid values? 4-100?
-    val = int(val)
-    if not 4 <= val <= 100:
-        raise ValueError(f"Minimum SOC / shallow charge ({val}) must be in [4-100]%")
-    return [WriteHoldingRegisterRequest(RegisterMap.BATTERY_SOC_RESERVE, val)]
-
-
-def set_battery_charge_limit(val: int) -> list[TransparentRequest]:
-    """Set the battery charge power limit as percentage. 50% (2.6 kW) is the maximum for most inverters."""
-    val = int(val)
-    if not 0 <= val <= 50:
-        raise ValueError(f"Specified Charge Limit ({val}%) is not in [0-50]%")
-    return [WriteHoldingRegisterRequest(RegisterMap.BATTERY_CHARGE_LIMIT, val)]
-
-
-def set_battery_discharge_limit(val: int) -> list[TransparentRequest]:
-    """Set the battery discharge power limit as percentage. 50% (2.6 kW) is the maximum for most inverters."""
-    val = int(val)
-    if not 0 <= val <= 50:
-        raise ValueError(f"Specified Discharge Limit ({val}%) is not in [0-50]%")
-    return [WriteHoldingRegisterRequest(RegisterMap.BATTERY_DISCHARGE_LIMIT, val)]
-
-
-def set_battery_power_reserve(val: int) -> list[TransparentRequest]:
-    """Set the battery power reserve to maintain."""
-    # TODO what are valid values?
-    val = int(val)
-    if not 4 <= val <= 100:
-        raise ValueError(f"Battery power reserve ({val}) must be in [4-100]%")
-    return [
-        WriteHoldingRegisterRequest(
-            RegisterMap.BATTERY_DISCHARGE_MIN_POWER_RESERVE, val
-        )
-    ]
-
-
-def set_battery_pause_mode(val: BatteryPauseMode) -> list[TransparentRequest]:
-    """Set the battery pause mode."""
-    if not 0 <= val <= 3:
-        raise ValueError(f"Battery pause mode ({val}) must be in [0-3]")
-    return [WriteHoldingRegisterRequest(RegisterMap.BATTERY_PAUSE_MODE, val)]
-
-
-def _set_charge_slot(
-    discharge: bool, idx: int, slot: Optional[TimeSlot]
-) -> list[TransparentRequest]:
-    hr_start, hr_end = (
-        getattr(RegisterMap, f'{"DIS" if discharge else ""}CHARGE_SLOT_{idx}_START'),
-        getattr(RegisterMap, f'{"DIS" if discharge else ""}CHARGE_SLOT_{idx}_END'),
-    )
-    if slot:
-        return [
-            WriteHoldingRegisterRequest(hr_start, int(slot.start.strftime("%H%M"))),
-            WriteHoldingRegisterRequest(hr_end, int(slot.end.strftime("%H%M"))),
+                base_register=180, register_count=60, slave_address=0x32
+            ),
         ]
-    else:
+        if complete:
+            requests.append(
+                ReadHoldingRegistersRequest(
+                    base_register=0, register_count=60, slave_address=0x32
+                )
+            )
+            requests.append(
+                ReadHoldingRegistersRequest(
+                    base_register=60, register_count=60, slave_address=0x32
+                )
+            )
+            requests.append(
+                ReadHoldingRegistersRequest(
+                    base_register=120, register_count=60, slave_address=0x32
+                )
+            )
+            requests.append(
+                ReadInputRegistersRequest(
+                    base_register=120, register_count=60, slave_address=0x32
+                )
+            )
+            number_batteries = max_batteries
+        for i in range(number_batteries):
+            requests.append(
+                ReadInputRegistersRequest(
+                    base_register=60, register_count=60, slave_address=0x32 + i
+                )
+            )
+        return requests
+
+    def disable_charge_target(self) -> list[TransparentRequest]:
+        """Removes SOC limit and target 100% charging."""
         return [
-            WriteHoldingRegisterRequest(hr_start, 0),
-            WriteHoldingRegisterRequest(hr_end, 0),
+            WriteHoldingRegisterRequest(RegisterMap.ENABLE_CHARGE_TARGET, False),
+            WriteHoldingRegisterRequest(RegisterMap.CHARGE_TARGET_SOC, 100),
         ]
 
+    def set_charge_target(self, target_soc: int) -> list[TransparentRequest]:
+        """Sets inverter to stop charging when SOC reaches the desired level. Also referred to as "winter mode"."""
+        if not 4 <= target_soc <= 100:
+            raise ValueError(f"Charge Target SOC ({target_soc}) must be in [4-100]%")
+        ret = self.set_enable_charge(True)
+        if target_soc == 100:
+            ret.extend(self.disable_charge_target())
+        else:
+            ret.append(
+                WriteHoldingRegisterRequest(RegisterMap.ENABLE_CHARGE_TARGET, True)
+            )
+            ret.append(
+                WriteHoldingRegisterRequest(RegisterMap.CHARGE_TARGET_SOC, target_soc)
+            )
+        return ret
 
-def set_charge_slot_1(timeslot: TimeSlot) -> list[TransparentRequest]:
-    """Set first charge slot start & end times."""
-    return _set_charge_slot(False, 1, timeslot)
+    def set_enable_charge(self, enabled: bool) -> list[TransparentRequest]:
+        """Enable the battery to charge, depending on the mode and slots set."""
+        return [WriteHoldingRegisterRequest(RegisterMap.ENABLE_CHARGE, enabled)]
 
+    def set_enable_discharge(self, enabled: bool) -> list[TransparentRequest]:
+        """Enable the battery to discharge, depending on the mode and slots set."""
+        return [WriteHoldingRegisterRequest(RegisterMap.ENABLE_DISCHARGE, enabled)]
 
-def reset_charge_slot_1() -> list[TransparentRequest]:
-    """Reset first charge slot to zero/disabled."""
-    return _set_charge_slot(False, 1, None)
+    def set_inverter_reboot(self) -> list[TransparentRequest]:
+        """Restart the inverter."""
+        return [WriteHoldingRegisterRequest(RegisterMap.REBOOT, 100)]
 
+    def set_calibrate_battery_soc(self) -> list[TransparentRequest]:
+        """Set the inverter to recalibrate the battery state of charge estimation."""
+        return [WriteHoldingRegisterRequest(RegisterMap.SOC_FORCE_ADJUST, 1)]
 
-def set_charge_slot_2(timeslot: TimeSlot) -> list[TransparentRequest]:
-    """Set second charge slot start & end times."""
-    return _set_charge_slot(False, 2, timeslot)
+    @deprecated("use set_enable_charge(True) instead")
+    def enable_charge(self) -> list[TransparentRequest]:
+        """Enable the battery to charge, depending on the mode and slots set."""
+        return self.set_enable_charge(True)
 
+    @deprecated("use set_enable_charge(False) instead")
+    def disable_charge(self) -> list[TransparentRequest]:
+        """Prevent the battery from charging at all."""
+        return self.set_enable_charge(False)
 
-def reset_charge_slot_2() -> list[TransparentRequest]:
-    """Reset second charge slot to zero/disabled."""
-    return _set_charge_slot(False, 2, None)
+    @deprecated("use set_enable_discharge(True) instead")
+    def enable_discharge(self) -> list[TransparentRequest]:
+        """Enable the battery to discharge, depending on the mode and slots set."""
+        return self.set_enable_discharge(True)
 
+    @deprecated("use set_enable_discharge(False) instead")
+    def disable_discharge(self) -> list[TransparentRequest]:
+        """Prevent the battery from discharging at all."""
+        return self.set_enable_discharge(False)
 
-def set_discharge_slot_1(timeslot: TimeSlot) -> list[TransparentRequest]:
-    """Set first discharge slot start & end times."""
-    return _set_charge_slot(True, 1, timeslot)
+    def set_discharge_mode_max_power(self) -> list[TransparentRequest]:
+        """Set the battery discharge mode to maximum power, exporting to the grid if it exceeds load demand."""
+        return [WriteHoldingRegisterRequest(RegisterMap.BATTERY_POWER_MODE, 0)]
 
+    def set_discharge_mode_to_match_demand(self) -> list[TransparentRequest]:
+        """Set the battery discharge mode to match demand, avoiding exporting power to the grid."""
+        return [WriteHoldingRegisterRequest(RegisterMap.BATTERY_POWER_MODE, 1)]
 
-def reset_discharge_slot_1() -> list[TransparentRequest]:
-    """Reset first discharge slot to zero/disabled."""
-    return _set_charge_slot(True, 1, None)
+    @deprecated("Use set_battery_soc_reserve(val) instead")
+    def set_shallow_charge(self, val: int) -> list[TransparentRequest]:
+        """Set the minimum level of charge to maintain."""
+        return self.set_battery_soc_reserve(val)
 
+    def set_battery_soc_reserve(self, val: int) -> list[TransparentRequest]:
+        """Set the minimum level of charge to maintain."""
+        # TODO what are valid values? 4-100?
+        val = int(val)
+        if not 4 <= val <= 100:
+            raise ValueError(
+                f"Minimum SOC / shallow charge ({val}) must be in [4-100]%"
+            )
+        return [WriteHoldingRegisterRequest(RegisterMap.BATTERY_SOC_RESERVE, val)]
 
-def set_discharge_slot_2(timeslot: TimeSlot) -> list[TransparentRequest]:
-    """Set second discharge slot start & end times."""
-    return _set_charge_slot(True, 2, timeslot)
+    def set_battery_charge_limit(self, val: int) -> list[TransparentRequest]:
+        """Set the battery charge power limit as percentage. 50% (2.6 kW) is the maximum for most inverters."""
+        val = int(val)
+        if not 0 <= val <= 50:
+            raise ValueError(f"Specified Charge Limit ({val}%) is not in [0-50]%")
+        return [WriteHoldingRegisterRequest(RegisterMap.BATTERY_CHARGE_LIMIT, val)]
 
+    def set_battery_discharge_limit(self, val: int) -> list[TransparentRequest]:
+        """Set the battery discharge power limit as percentage. 50% (2.6 kW) is the maximum for most inverters."""
+        val = int(val)
+        if not 0 <= val <= 50:
+            raise ValueError(f"Specified Discharge Limit ({val}%) is not in [0-50]%")
+        return [WriteHoldingRegisterRequest(RegisterMap.BATTERY_DISCHARGE_LIMIT, val)]
 
-def reset_discharge_slot_2() -> list[TransparentRequest]:
-    """Reset second discharge slot to zero/disabled."""
-    return _set_charge_slot(True, 2, None)
+    def set_battery_power_reserve(self, val: int) -> list[TransparentRequest]:
+        """Set the battery power reserve to maintain."""
+        # TODO what are valid values?
+        val = int(val)
+        if not 4 <= val <= 100:
+            raise ValueError(f"Battery power reserve ({val}) must be in [4-100]%")
+        return [
+            WriteHoldingRegisterRequest(
+                RegisterMap.BATTERY_DISCHARGE_MIN_POWER_RESERVE, val
+            )
+        ]
 
+    def set_battery_pause_mode(self, val: BatteryPauseMode) -> list[TransparentRequest]:
+        """Set the battery pause mode."""
+        if not 0 <= val <= 3:
+            raise ValueError(f"Battery pause mode ({val}) must be in [0-3]")
+        return [WriteHoldingRegisterRequest(RegisterMap.BATTERY_PAUSE_MODE, val)]
 
-def set_system_date_time(dt: datetime) -> list[TransparentRequest]:
-    """Set the date & time of the inverter."""
-    return [
-        WriteHoldingRegisterRequest(RegisterMap.SYSTEM_TIME_YEAR, dt.year - 2000),
-        WriteHoldingRegisterRequest(RegisterMap.SYSTEM_TIME_MONTH, dt.month),
-        WriteHoldingRegisterRequest(RegisterMap.SYSTEM_TIME_DAY, dt.day),
-        WriteHoldingRegisterRequest(RegisterMap.SYSTEM_TIME_HOUR, dt.hour),
-        WriteHoldingRegisterRequest(RegisterMap.SYSTEM_TIME_MINUTE, dt.minute),
-        WriteHoldingRegisterRequest(RegisterMap.SYSTEM_TIME_SECOND, dt.second),
-    ]
+    def _set_charge_slot(
+        self, discharge: bool, idx: int, slot: Optional[TimeSlot]
+    ) -> list[TransparentRequest]:
+        hr_start, hr_end = (
+            getattr(
+                RegisterMap, f'{"DIS" if discharge else ""}CHARGE_SLOT_{idx}_START'
+            ),
+            getattr(RegisterMap, f'{"DIS" if discharge else ""}CHARGE_SLOT_{idx}_END'),
+        )
+        if slot:
+            return [
+                WriteHoldingRegisterRequest(hr_start, int(slot.start.strftime("%H%M"))),
+                WriteHoldingRegisterRequest(hr_end, int(slot.end.strftime("%H%M"))),
+            ]
+        else:
+            return [
+                WriteHoldingRegisterRequest(hr_start, 0),
+                WriteHoldingRegisterRequest(hr_end, 0),
+            ]
 
+    def set_charge_slot_1(self, timeslot: TimeSlot) -> list[TransparentRequest]:
+        """Set first charge slot start & end times."""
+        return self._set_charge_slot(False, 1, timeslot)
 
-def set_mode_dynamic() -> list[TransparentRequest]:
-    """Set system to Dynamic / Eco mode.
+    def reset_charge_slot_1(self) -> list[TransparentRequest]:
+        """Reset first charge slot to zero/disabled."""
+        return self._set_charge_slot(False, 1, None)
 
-    This mode is designed to maximise use of solar generation. The battery will charge from excess solar
-    generation to avoid exporting power, and discharge to meet load demand when solar power is insufficient to
-    avoid importing power. This mode is useful if you want to maximise self-consumption of renewable generation
-    and minimise the amount of energy drawn from the grid.
-    """
-    # r27=1 r110=4 r59=0
-    return (
-        set_discharge_mode_to_match_demand()
-        + set_battery_soc_reserve(4)
-        + set_enable_discharge(False)
-    )
+    def set_charge_slot_2(self, timeslot: TimeSlot) -> list[TransparentRequest]:
+        """Set second charge slot start & end times."""
+        return self._set_charge_slot(False, 2, timeslot)
 
+    def reset_charge_slot_2(self) -> list[TransparentRequest]:
+        """Reset second charge slot to zero/disabled."""
+        return self._set_charge_slot(False, 2, None)
 
-def set_mode_storage(
-    discharge_slot_1: TimeSlot = TimeSlot.from_repr(1600, 700),
-    discharge_slot_2: Optional[TimeSlot] = None,
-    discharge_for_export: bool = False,
-) -> list[TransparentRequest]:
-    """Set system to storage mode with specific discharge slots(s).
+    def set_discharge_slot_1(self, timeslot: TimeSlot) -> list[TransparentRequest]:
+        """Set first discharge slot start & end times."""
+        return self._set_charge_slot(True, 1, timeslot)
 
-    This mode stores excess solar generation during the day and holds that energy ready for use later in the day.
-    By default, the battery will start to discharge from 4pm-7am to cover energy demand during typical peak
-    hours. This mode is particularly useful if you get charged more for your electricity at certain times to
-    utilise the battery when it is most effective. If the second time slot isn't specified, it will be cleared.
+    def reset_discharge_slot_1(self) -> list[TransparentRequest]:
+        """Reset first discharge slot to zero/disabled."""
+        return self._set_charge_slot(True, 1, None)
 
-    You can optionally also choose to export excess energy: instead of discharging to meet only your load demand,
-    the battery will discharge at full power and any excess will be exported to the grid. This is useful if you
-    have a variable export tariff (e.g. Agile export) and you want to target the peak times of day (e.g. 4pm-7pm)
-    when it is most valuable to export energy.
-    """
-    if discharge_for_export:
-        ret = set_discharge_mode_max_power()  # r27=0
-    else:
-        ret = set_discharge_mode_to_match_demand()  # r27=1
-    ret.extend(set_battery_soc_reserve(100))  # r110=100
-    ret.extend(set_enable_discharge(True))  # r59=1
-    ret.extend(set_discharge_slot_1(discharge_slot_1))  # r56=1600, r57=700
-    if discharge_slot_2:
-        ret.extend(set_discharge_slot_2(discharge_slot_2))  # r56=1600, r57=700
-    else:
-        ret.extend(reset_discharge_slot_2())
-    return ret
+    def set_discharge_slot_2(self, timeslot: TimeSlot) -> list[TransparentRequest]:
+        """Set second discharge slot start & end times."""
+        return self._set_charge_slot(True, 2, timeslot)
+
+    def reset_discharge_slot_2(self) -> list[TransparentRequest]:
+        """Reset second discharge slot to zero/disabled."""
+        return self._set_charge_slot(True, 2, None)
+
+    def set_system_date_time(self, dt: datetime) -> list[TransparentRequest]:
+        """Set the date & time of the inverter."""
+        return [
+            WriteHoldingRegisterRequest(RegisterMap.SYSTEM_TIME_YEAR, dt.year - 2000),
+            WriteHoldingRegisterRequest(RegisterMap.SYSTEM_TIME_MONTH, dt.month),
+            WriteHoldingRegisterRequest(RegisterMap.SYSTEM_TIME_DAY, dt.day),
+            WriteHoldingRegisterRequest(RegisterMap.SYSTEM_TIME_HOUR, dt.hour),
+            WriteHoldingRegisterRequest(RegisterMap.SYSTEM_TIME_MINUTE, dt.minute),
+            WriteHoldingRegisterRequest(RegisterMap.SYSTEM_TIME_SECOND, dt.second),
+        ]
+
+    def set_mode_dynamic(self) -> list[TransparentRequest]:
+        """Set system to Dynamic / Eco mode.
+
+        This mode is designed to maximise use of solar generation. The battery will
+        charge from excess solar generation to avoid exporting power, and discharge
+        to meet load demand when solar power is insufficient to avoid importing power.
+        This mode is useful if you want to maximise self-consumption of renewable
+        generation and minimise the amount of energy drawn from the grid.
+        """
+        # r27=1 r110=4 r59=0
+        return (
+            self.set_discharge_mode_to_match_demand()
+            + self.set_battery_soc_reserve(4)
+            + self.set_enable_discharge(False)
+        )
+
+    def set_mode_storage(
+        self,
+        discharge_slot_1: TimeSlot = TimeSlot.from_repr(1600, 700),
+        discharge_slot_2: Optional[TimeSlot] = None,
+        discharge_for_export: bool = False,
+    ) -> list[TransparentRequest]:
+        """Set system to storage mode with specific discharge slots(s).
+
+        This mode stores excess solar generation during the day and holds that energy
+        ready for use later in the day. By default, the battery will start to discharge
+        from 4pm-7am to cover energy demand during typical peak hours. This mode is
+        particularly useful if you get charged more for your electricity at certain
+        times to utilise the battery when it is most effective. If the second time slot
+        isn't specified, it will be cleared.
+
+        You can optionally also choose to export excess energy: instead of discharging
+        to meet only your load demand, the battery will discharge at full power and any
+        excess will be exported to the grid. This is useful if you have a variable
+        export tariff (e.g. Agile export) and you want to target the peak times of
+        day (e.g. 4pm-7pm) when it is most valuable to export energy.
+        """
+        if discharge_for_export:
+            ret = self.set_discharge_mode_max_power()  # r27=0
+        else:
+            ret = self.set_discharge_mode_to_match_demand()  # r27=1
+        ret.extend(self.set_battery_soc_reserve(100))  # r110=100
+        ret.extend(self.set_enable_discharge(True))  # r59=1
+        ret.extend(self.set_discharge_slot_1(discharge_slot_1))  # r56=1600, r57=700
+        if discharge_slot_2:
+            ret.extend(self.set_discharge_slot_2(discharge_slot_2))  # r56=1600, r57=700
+        else:
+            ret.extend(self.reset_discharge_slot_2())
+        return ret

--- a/givenergy_modbus/model/inverter.py
+++ b/givenergy_modbus/model/inverter.py
@@ -129,6 +129,7 @@ class Status(IntEnum):
     FAULT = 3
     FLASHING_FIRMWARE_UPDATE = 4
 
+
 class Phase(StrEnum):
     """Determine number of Phases."""
 
@@ -219,7 +220,9 @@ class Inverter(RegisterGetter, metaclass=DynamicDoc):
         "grid_port_max_power_output": Def(C.uint16, None, HR(26)),
         "battery_power_mode": Def(C.uint16, BatteryPowerMode, HR(27), valid=(0, 1)),
         "enable_60hz_freq_mode": Def(C.bool, None, HR(28)),
-        "soc_force_adjust": Def(C.uint16, BatteryCalibrationStage, HR(29)),
+        "soc_force_adjust": Def(
+            C.uint16, BatteryCalibrationStage, HR(29), valid=(0, 3)
+        ),
         "modbus_address": Def(C.uint16, None, HR(30)),
         # gen-1 defines HR(31)/HR(32) as charge_slot_2, but later generations
         # define it at HR(243)/HR(244) instead.
@@ -230,6 +233,12 @@ class Inverter(RegisterGetter, metaclass=DynamicDoc):
         "system_time": Def(
             C.datetime, None, HR(35), HR(36), HR(37), HR(38), HR(39), HR(40)
         ),
+        "system_time_year": Def(C.uint16, None, HR(35), valid=(0, 65535)),
+        "system_time_month": Def(C.uint16, None, HR(36), valid=(1, 12)),
+        "system_time_day": Def(C.uint16, None, HR(37), valid=(1, 31)),
+        "system_time_hour": Def(C.uint16, None, HR(38), valid=(0, 23)),
+        "system_time_minute": Def(C.uint16, None, HR(39), valid=(0, 59)),
+        "system_time_second": Def(C.uint16, None, HR(40), valid=(0, 59)),
         "enable_drm_rj45_port": Def(C.bool, None, HR(41)),
         "enable_reversed_ct_clamp": Def(C.bool, None, HR(42)),
         "charge_soc": Def((C.duint8, 0), None, HR(43)),
@@ -252,7 +261,7 @@ class Inverter(RegisterGetter, metaclass=DynamicDoc):
         "discharge_slot_1_start": Def(C.uint16, None, HR(56), valid=(0, 2359)),
         "discharge_slot_1_end": Def(C.uint16, None, HR(57), valid=(0, 2359)),
         "enable_auto_judge_battery_type": Def(C.bool, None, HR(58)),
-        "enable_discharge": Def(C.bool, None, HR(59)),
+        "enable_discharge": Def(C.bool, None, HR(59), valid=(0, 1)),
         #
         # Holding Registers, block 60-119
         #
@@ -263,7 +272,7 @@ class Inverter(RegisterGetter, metaclass=DynamicDoc):
         "charge_slot_1": Def(C.timeslot, None, HR(94), HR(95)),
         "charge_slot_1_start": Def(C.uint16, None, HR(94), valid=(0, 2359)),
         "charge_slot_1_end": Def(C.uint16, None, HR(95), valid=(0, 2359)),
-        "enable_charge": Def(C.bool, None, HR(96)),
+        "enable_charge": Def(C.bool, None, HR(96), valid=(0, 1)),
         "battery_low_voltage_protection_limit": Def(C.uint16, C.centi, HR(97)),
         "battery_high_voltage_protection_limit": Def(C.uint16, C.centi, HR(98)),
         # skip voltage adjustment settings 99-104
@@ -272,7 +281,7 @@ class Inverter(RegisterGetter, metaclass=DynamicDoc):
         # skip voltage adjustment settings 106-107
         "battery_low_force_charge_time": Def(C.uint16, None, HR(108)),
         "enable_bms_read": Def(C.bool, None, HR(109)),
-        "battery_soc_reserve": Def(C.uint16, None, HR(110)),
+        "battery_soc_reserve": Def(C.uint16, None, HR(110), valid=(4, 100)),
         "battery_charge_limit": Def(C.uint16, None, HR(111), valid=(0, 50)),
         "battery_discharge_limit": Def(C.uint16, None, HR(112), valid=(0, 50)),
         "enable_buzzer": Def(C.bool, None, HR(113)),
@@ -297,7 +306,7 @@ class Inverter(RegisterGetter, metaclass=DynamicDoc):
         "start_system_auto_test": Def(C.bool, None, HR(127)),
         "enable_spi": Def(C.bool, None, HR(128)),
         # skip PF configuration and protection settings 129-166
-        "inverter_reboot": Def(C.uint16, None, HR(163)),
+        "inverter_reboot": Def(C.uint16, None, HR(163), valid=(100, 100)),
         "threephase_balance_mode": Def(C.uint16, None, HR(167)),
         "threephase_abc": Def(C.uint16, None, HR(168)),
         "threephase_balance_1": Def(C.uint16, None, HR(169)),

--- a/tests/client/test_commands.py
+++ b/tests/client/test_commands.py
@@ -1,11 +1,13 @@
 import arrow
 import pytest
 
-from givenergy_modbus.client import commands
+from givenergy_modbus.client.client import Client
 from givenergy_modbus.client.commands import RegisterMap
 from givenergy_modbus.model import TimeSlot
 from givenergy_modbus.pdu import WriteHoldingRegisterRequest
 
+client = Client('foo', 1234)
+commands = client.commands
 
 async def test_configure_charge_target():
     """Ensure we can set and disable a charge target."""

--- a/tests/client/test_commands.py
+++ b/tests/client/test_commands.py
@@ -4,6 +4,7 @@ import pytest
 from givenergy_modbus.client.client import Client
 from givenergy_modbus.client.commands import RegisterMap
 from givenergy_modbus.model import TimeSlot
+from givenergy_modbus.model.inverter import BatteryPauseMode
 from givenergy_modbus.pdu import WriteHoldingRegisterRequest
 
 client = Client('foo', 1234)
@@ -62,7 +63,15 @@ async def test_set_battery_discharge_mode():
         WriteHoldingRegisterRequest(RegisterMap.BATTERY_POWER_MODE, 1)
     ]
 
-
+def test_set_battery_pause_mode():
+    """Test battery_pause_mode"""
+    assert commands.set_battery_pause_mode(BatteryPauseMode.DISABLED) == [WriteHoldingRegisterRequest(RegisterMap.BATTERY_PAUSE_MODE, 0)]
+    assert commands.set_battery_pause_mode(BatteryPauseMode.PAUSE_CHARGE) == [WriteHoldingRegisterRequest(RegisterMap.BATTERY_PAUSE_MODE, 1)]
+    assert commands.set_battery_pause_mode(BatteryPauseMode.PAUSE_DISCHARGE) == [WriteHoldingRegisterRequest(RegisterMap.BATTERY_PAUSE_MODE, 2)]
+    assert commands.set_battery_pause_mode(BatteryPauseMode.PAUSE_BOTH) == [WriteHoldingRegisterRequest(RegisterMap.BATTERY_PAUSE_MODE, 3)]
+    with pytest.raises(ValueError, match=r'Battery pause mode \(5\) must be in \[0-3\]'):
+        commands.set_battery_pause_mode(5)
+                                                                            
 @pytest.mark.parametrize('action', ('charge', 'discharge'))
 @pytest.mark.parametrize('slot', (1, 2))
 @pytest.mark.parametrize('hour1', (0, 23))

--- a/tests/client/test_commands.py
+++ b/tests/client/test_commands.py
@@ -2,10 +2,43 @@ import arrow
 import pytest
 
 from givenergy_modbus.client.client import Client
-from givenergy_modbus.client.commands import RegisterMap
 from givenergy_modbus.model import TimeSlot
 from givenergy_modbus.model.inverter import BatteryPauseMode
 from givenergy_modbus.pdu import WriteHoldingRegisterRequest
+
+
+class RegisterMap:
+    """Mapping of holding register function to location."""
+
+    ENABLE_CHARGE_TARGET = 20
+    BATTERY_POWER_MODE = 27
+    SOC_FORCE_ADJUST = 29
+    CHARGE_SLOT_2_START = 243
+    CHARGE_SLOT_2_END = 244
+    SYSTEM_TIME_YEAR = 35
+    SYSTEM_TIME_MONTH = 36
+    SYSTEM_TIME_DAY = 37
+    SYSTEM_TIME_HOUR = 38
+    SYSTEM_TIME_MINUTE = 39
+    SYSTEM_TIME_SECOND = 40
+    DISCHARGE_SLOT_2_START = 44
+    DISCHARGE_SLOT_2_END = 45
+    ACTIVE_POWER_RATE = 50
+    DISCHARGE_SLOT_1_START = 56
+    DISCHARGE_SLOT_1_END = 57
+    ENABLE_DISCHARGE = 59
+    CHARGE_SLOT_1_START = 94
+    CHARGE_SLOT_1_END = 95
+    ENABLE_CHARGE = 96
+    BATTERY_SOC_RESERVE = 110
+    BATTERY_CHARGE_LIMIT = 111
+    BATTERY_DISCHARGE_LIMIT = 112
+    BATTERY_DISCHARGE_MIN_POWER_RESERVE = 114
+    CHARGE_TARGET_SOC = 116
+    REBOOT = 163
+    BATTERY_PAUSE_MODE = 318
+
+
 
 client = Client('foo', 1234)
 commands = client.commands
@@ -23,11 +56,11 @@ async def test_configure_charge_target():
         WriteHoldingRegisterRequest(RegisterMap.CHARGE_TARGET_SOC, 100),
     ]
 
-    with pytest.raises(ValueError, match=r'Charge Target SOC \(0\) must be in \[4-100\]\%'):
+    with pytest.raises(ValueError, match=r'0 out of range for charge_target_soc'):
         commands.set_charge_target(0)
-    with pytest.raises(ValueError, match=r'Charge Target SOC \(1\) must be in \[4-100\]\%'):
+    with pytest.raises(ValueError, match=r'1 out of range for charge_target_soc'):
         commands.set_charge_target(1)
-    with pytest.raises(ValueError, match=r'Charge Target SOC \(101\) must be in \[4-100\]\%'):
+    with pytest.raises(ValueError, match=r'101 out of range for charge_target_soc'):
         commands.set_charge_target(101)
 
     assert commands.disable_charge_target() == [
@@ -69,7 +102,7 @@ def test_set_battery_pause_mode():
     assert commands.set_battery_pause_mode(BatteryPauseMode.PAUSE_CHARGE) == [WriteHoldingRegisterRequest(RegisterMap.BATTERY_PAUSE_MODE, 1)]
     assert commands.set_battery_pause_mode(BatteryPauseMode.PAUSE_DISCHARGE) == [WriteHoldingRegisterRequest(RegisterMap.BATTERY_PAUSE_MODE, 2)]
     assert commands.set_battery_pause_mode(BatteryPauseMode.PAUSE_BOTH) == [WriteHoldingRegisterRequest(RegisterMap.BATTERY_PAUSE_MODE, 3)]
-    with pytest.raises(ValueError, match=r'Battery pause mode \(5\) must be in \[0-3\]'):
+    with pytest.raises(ValueError, match=r'5 out of range for battery_pause_mode'):
         commands.set_battery_pause_mode(5)
                                                                             
 @pytest.mark.parametrize('action', ('charge', 'discharge'))
@@ -156,9 +189,9 @@ async def test_set_charge_and_discharge_limits():
         WriteHoldingRegisterRequest(RegisterMap.BATTERY_DISCHARGE_LIMIT, 50, slave_address=0x11),
     ]
 
-    with pytest.raises(ValueError, match=r'Specified Charge Limit \(51%\) is not in \[0-50\]\%'):
+    with pytest.raises(ValueError, match=r'51 out of range for battery_charge_limit'):
         commands.set_battery_charge_limit(51)
-    with pytest.raises(ValueError, match=r'Specified Discharge Limit \(51%\) is not in \[0-50\]\%'):
+    with pytest.raises(ValueError, match=r'51 out of range for battery_discharge_limit'):
         commands.set_battery_discharge_limit(51)
 
 


### PR DESCRIPTION
As a reminder, applications should now be using  commands = client.commands()  rather than importing commands directly.

This transitions commands over from a collection of simple methods to a class. In the future, that class will have access to the plant (via the client) and will therefore be able to tune behaviour to match the actual system it's connected to. For now, it still hardcodes Inverter.

There should be no changes required at point of use, if I've done it right.  Unless applications had done something like
`from commands import *`
so that they were able to invoke a command with the `commands.` prefix - in that case, they will have to introduce a commands instance to the call.
